### PR TITLE
fixing isObject() method for old IE browsers

### DIFF
--- a/encoding.js
+++ b/encoding.js
@@ -3131,7 +3131,8 @@ function assignEncodingName(target) {
 // Helpers
 
 function isObject(x) {
-  return toString.call(x) === '[object Object]';
+    var type = typeof obj;
+    return type === 'function' || type === 'object' && !!obj;
 }
 
 function isArray(x) {


### PR DESCRIPTION
Object.prototype.toString.call(undefined) returns "[object Object]" in IE8. It means what converting 'x' to string is not the best way for this function. On the other side, we can use the code from underscore library, which works even in IE8
