### PR TITLE
Fix argument decision of the detect method

### DIFF
--- a/encoding.js
+++ b/encoding.js
@@ -199,7 +199,7 @@ var Encoding = {
       return false;
     }
 
-    if (isObject(encodings)) {
+    if (isObject(encodings) && !isArray(encodings)) {
       encodings = encodings.encoding;
     }
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -136,6 +136,19 @@ describe('Encoding', function() {
       assert(encoding.detect(utf32le, 'utf-32'));
       assert(encoding.detect(utf32le) === 'UTF32');
     });
+
+    it('Specifying multiple encodings', function() {
+      var unicode = 'ユニコード';
+
+      assert.equal(encoding.detect(unicode, 'UNICODE'), 'UNICODE');
+      assert.equal(encoding.detect(unicode, ['UNICODE']), 'UNICODE');
+      assert.equal(encoding.detect(unicode, {encoding: 'UNICODE'}), 'UNICODE');
+      assert.equal(encoding.detect(unicode, {encoding: ['UNICODE']}), 'UNICODE');
+      assert.equal(encoding.detect(unicode, []), false);
+      assert.equal(encoding.detect(unicode, ['UNICODE', 'ASCII']), 'UNICODE');
+      assert.equal(encoding.detect(unicode, 'ASCII, EUCJP, UNICODE'), 'UNICODE');
+      assert.equal(encoding.detect(unicode, ['SJIS', 'UTF8', 'ASCII']), false);
+    });
   });
 
   describe('convert', function() {


### PR DESCRIPTION
JavaScriptの実装では`typeof ['foo']`は`'object'`を返すので，`detect`メソッドの第2引数に配列を入れた際それはオブジェクトとみなされて無視されるようになっていました．

ここでは`isObject`は修正せず，ひとまず`isArray`で追加のチェックを行うよう修正しています．