### PR TITLE
SJIS, EUC-JP, JISに変換できないときに該当の文字を無視するオプションを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Convert and detect character encoding in JavaScript.
     + [Specify conversion options to the argument `to` as an object](#specify-conversion-options-to-the-argument-to-as-an-object)
     + [Specify the return type by the `type` option](#specify-the-return-type-by-the-type-option)
     + [Replacing characters with HTML entities when they cannot be represented](#replacing-characters-with-html-entities-when-they-cannot-be-represented)
+    + [Ignoring characters when they cannot be represented](#ignoring-characters-when-they-cannot-be-represented)
     + [Specify BOM in UTF-16](#specify-bom-in-utf-16)
   * [urlEncode : Encodes to percent-encoded string](#encodingurlencode-data)
   * [urlDecode : Decodes from percent-encoded string](#encodingurldecode-string)
@@ -403,6 +404,30 @@ const sjisArray = Encoding.convert(unicodeArray, {
   fallback: 'html-entity-hex'
 });
 console.log(sjisArray); // Converted to a code array of 'ホッケの漢字は&#x29e3d;'
+```
+
+#### Ignoring characters when they cannot be represented
+
+By specifying `ignore` as a `fallback` option, characters that cannot be represented in the target encoding format can be ignored.
+
+Example of specifying `{ fallback: 'ignore' }` option:
+
+```javascript
+const unicodeArray = Encoding.stringToCode("寿司🍣ビール🍺");
+// No fallback specified
+let sjisArray = Encoding.convert(unicodeArray, {
+  to: "SJIS",
+  from: "UNICODE",
+});
+console.log(sjisArray); // Converted to a code array of '寿司?ビール?'
+
+// Specify `fallback: html-entity`
+sjisArray = Encoding.convert(unicodeArray, {
+  to: "SJIS",
+  from: "UNICODE",
+  fallback: "ignore",
+});
+console.log(sjisArray); // Converted to a code array of '寿司ビール'
 ```
 
 #### Specify BOM in UTF-16

--- a/README_ja.md
+++ b/README_ja.md
@@ -28,6 +28,7 @@ JavaScript で文字コードの変換や判定をします。
     + [引数 `to` にオブジェクトで変換オプションを指定する](#引数-to-にオブジェクトで変換オプションを指定する)
     + [`type` オプションで戻り値の型を指定する](#type-オプションで戻り値の型を指定する)
     + [変換できない文字を HTML エンティティ (HTML 数値文字参照) に置き換える](#変換できない文字を-html-エンティティ-html-数値文字参照-に置き換える)
+    + [変換できない文字を無視する](#変換できない文字を無視する)
     + [UTF-16 に BOM をつける](#utf-16-に-bom-をつける)
   * [urlEncode : 文字コードの配列をURLエンコードする](#encodingurlencode-data)
   * [urlDecode : 文字コードの配列にURLデコードする](#encodingurldecode-string)
@@ -393,6 +394,30 @@ const sjisArray = Encoding.convert(unicodeArray, {
   fallback: 'html-entity-hex'
 });
 console.log(sjisArray); // 'ホッケの漢字は&#x29e3d;' の数値配列に変換されます
+```
+
+#### 変換できない文字を無視する
+
+変換先の文字コードで表現できない文字を無視するには、 `fallback` オプションに `ignore` を指定します。
+
+`{ fallback: 'ignore' }` オプションを指定する例:
+
+```javascript
+const unicodeArray = Encoding.stringToCode('寿司🍣ビール🍺');
+// fallback指定なし
+let sjisArray = Encoding.convert(unicodeArray, {
+  to: 'SJIS',
+  from: 'UNICODE'
+});
+console.log(sjisArray); // '寿司?ビール?' の数値配列に変換されます
+
+// `fallback: ignore`を指定
+sjisArray = Encoding.convert(unicodeArray, {
+  to: 'SJIS',
+  from: 'UNICODE',
+  fallback: 'ignore'
+});
+console.log(sjisArray); // '寿司ビール' の数値配列に変換されます
 ```
 
 #### UTF-16 に BOM をつける

--- a/encoding.js
+++ b/encoding.js
@@ -1824,6 +1824,9 @@ function handleFallback(results, bytes, fallbackOption) {
         }
         results[results.length] = 0x3B; // ;
       }
+      break;
+    case 'ignore':
+      break;
   }
 }
 

--- a/src/encoding-convert.js
+++ b/src/encoding-convert.js
@@ -1672,5 +1672,8 @@ function handleFallback(results, bytes, fallbackOption) {
         }
         results[results.length] = 0x3B; // ;
       }
+      break;
+    case 'ignore':
+      break;
   }
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -636,6 +636,50 @@ describe('encoding', function() {
           assert.deepEqual(decoded, '&#127843;寿司ビール&#127866;');
         });
       });
+
+      describe('Ignore untranslatable unknown characters', function() {
+        it('SJIS', function() {
+          // Characters that cannot be converted to Shift_JIS ('🍣', '🍺') will be ignored.
+          var sjis = encoding.convert(utf8, {
+            to: 'sjis',
+            from: 'utf-8',
+            fallback: 'ignore'
+          });
+          var decoded = encoding.convert(sjis, {
+            to: 'unicode',
+            from: 'sjis'
+          });
+          assert.deepEqual(decoded, '寿司ビール');
+        });
+
+        it('EUC-JP', function() {
+          // Characters that cannot be converted to EUC-JP ('🍣', '🍺') will be ignored.
+          var eucjp = encoding.convert(utf8, {
+            to: 'euc-jp',
+            from: 'utf-8',
+            fallback: 'ignore'
+          });
+          var decoded = encoding.convert(eucjp, {
+            to: 'unicode',
+            from: 'euc-jp'
+          });
+          assert.deepEqual(decoded, '寿司ビール');
+        });
+
+        it('JIS', function() {
+          // Characters that cannot be converted to JIS ('🍣', '🍺') will be ignored.
+          var jis = encoding.convert(utf8, {
+            to: 'jis',
+            from: 'utf-8',
+            fallback: 'ignore'
+          });
+          var decoded = encoding.convert(jis, {
+            to: 'unicode',
+            from: 'jis'
+          });
+          assert.deepEqual(decoded, '寿司ビール');
+        });
+      });
     });
   });
 


### PR DESCRIPTION
* 別の文字コードへの変換時に変換不可能な文字が含まれる時、fallbackの表現への置き換えではなく、単にそれを無視するオプションが必要となったため追加させていただきたいです。
  - オプションの名前にはこだわりは無く、もし `ignore` が望ましくなければ、他のものでも問題ありません。
  - 実は、現行の実装でも、存在しないfallbackOptionを指定することでこの振る舞いを実現することが出来ますが、今後同じ挙動をすることが保証されないため、明示的に無視できるオプションを追加させていただきたいです。
* このオプションがあれば、例えば `🍣寿司ビール🍺` (UNICODE) が `?寿司ビール?` (Shift_JIS) に変換されていたものを `寿司ビール` (Shift_JIS) に変換可能となります。
* こちらのご対応をもし取り込んでいただけましたら、DefinitelyTypedの方にもPRを出させていただきます。
* 関連PR: #23 