### PR TITLE
fix comment in example code for fallback-ignore option of convert function

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ let sjisArray = Encoding.convert(unicodeArray, {
 });
 console.log(sjisArray); // Converted to a code array of '寿司?ビール?'
 
-// Specify `fallback: html-entity`
+// Specify `fallback: ignore`
 sjisArray = Encoding.convert(unicodeArray, {
   to: "SJIS",
   from: "UNICODE",


### PR DESCRIPTION
#41 の変更で追加したドキュメンテーションのうち、英語版の方でコード例中のコメントに誤りがあったため修正しました。