### PR TITLE
feat: add `error` fallback option in Encoding.convert

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Convert and detect character encoding in JavaScript.
     + [Specify the return type by the `type` option](#specify-the-return-type-by-the-type-option)
     + [Replacing characters with HTML entities when they cannot be represented](#replacing-characters-with-html-entities-when-they-cannot-be-represented)
     + [Ignoring characters when they cannot be represented](#ignoring-characters-when-they-cannot-be-represented)
+    + [Raising an Error when they cannot be represented](#raising-an-error-when-they-cannot-be-represented)
     + [Specify BOM in UTF-16](#specify-bom-in-utf-16)
   * [urlEncode : Encodes to percent-encoded string](#encodingurlencode-data)
   * [urlDecode : Decodes from percent-encoded string](#encodingurldecode-string)
@@ -428,6 +429,24 @@ sjisArray = Encoding.convert(unicodeArray, {
   fallback: "ignore",
 });
 console.log(sjisArray); // Converted to a code array of '寿司ビール'
+```
+
+#### Raising an Error when they cannot be represented
+
+If you need to throw an error when a character cannot be represented in the target character encoding,
+specify `error` as a `fallback` option. This will cause an exception to be thrown.
+
+```javascript
+const unicodeArray = Encoding.stringToCode('おにぎり🍙ラーメン🍜');
+try {
+  const sjisArray = Encoding.convert(unicodeArray, {
+    to: 'SJIS',
+    from: 'UNICODE',
+    fallback: 'error' // Specify 'error' to throw an exception
+  });
+} catch (e) {
+  console.error(e); // Error: Character cannot be represented: [240, 159, 141, 153]
+}
 ```
 
 #### Specify BOM in UTF-16

--- a/README_ja.md
+++ b/README_ja.md
@@ -29,6 +29,7 @@ JavaScript で文字コードの変換や判定をします。
     + [`type` オプションで戻り値の型を指定する](#type-オプションで戻り値の型を指定する)
     + [変換できない文字を HTML エンティティ (HTML 数値文字参照) に置き換える](#変換できない文字を-html-エンティティ-html-数値文字参照-に置き換える)
     + [変換できない文字を無視する](#変換できない文字を無視する)
+    + [変換できない文字が含まれている場合にエラーを発生させる](#変換できない文字が含まれている場合にエラーを発生させる)
     + [UTF-16 に BOM をつける](#utf-16-に-bom-をつける)
   * [urlEncode : 文字コードの配列をURLエンコードする](#encodingurlencode-data)
   * [urlDecode : 文字コードの配列にURLデコードする](#encodingurldecode-string)
@@ -418,6 +419,23 @@ sjisArray = Encoding.convert(unicodeArray, {
   fallback: 'ignore'
 });
 console.log(sjisArray); // '寿司ビール' の数値配列に変換されます
+```
+
+#### 変換できない文字が含まれている場合にエラーを発生させる
+
+`fallback` オプションに `error` を指定すると、変換先の文字コードで表現できない文字が含まれている場合にエラーが発生し、例外が投げられます。
+
+```javascript
+const unicodeArray = Encoding.stringToCode('おにぎり🍙ラーメン🍜');
+try {
+  const sjisArray = Encoding.convert(unicodeArray, {
+    to: 'SJIS',
+    from: 'UNICODE',
+    fallback: 'error' // 'error'を指定
+  });
+} catch (e) {
+  console.error(e); // Error: Character cannot be represented: [240, 159, 141, 153]
+}
 ```
 
 #### UTF-16 に BOM をつける

--- a/src/encoding-convert.js
+++ b/src/encoding-convert.js
@@ -1673,6 +1673,8 @@ function handleFallback(results, bytes, fallbackOption) {
         results[results.length] = 0x3B; // ;
       }
       break;
+    case 'error':
+      throw new Error('Character cannot be represented: [' + bytes.join(', ') + ']');
     case 'ignore':
       break;
   }

--- a/tests/test.js
+++ b/tests/test.js
@@ -680,6 +680,41 @@ describe('encoding', function() {
           assert.deepEqual(decoded, '寿司ビール');
         });
       });
+
+      describe('Raise an Error when characters cannot be represented', function() {
+        it('SJIS', function() {
+          var fn = function() {
+            encoding.convert(utf8, {
+              to: 'sjis',
+              from: 'utf-8',
+              fallback: 'error'
+            });
+          };
+          assert.throws(fn, Error, 'Character cannot be represented: [240, 159, 141, 163]');
+        });
+
+        it('EUC-JP', function() {
+          var fn = function() {
+            encoding.convert(utf8, {
+              to: 'euc-jp',
+              from: 'utf-8',
+              fallback: 'error'
+            });
+          };
+          assert.throws(fn, Error, 'Character cannot be represented: [240, 159, 141, 163]');
+        });
+
+        it('JIS', function() {
+          var fn = function() {
+            encoding.convert(utf8, {
+              to: 'jis',
+              from: 'utf-8',
+              fallback: 'error'
+            });
+          };
+          assert.throws(fn, Error, 'Character cannot be represented: [240, 159, 141, 163]');
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Resolve #43 

Added a new `{ fallback: 'error' }` option to `Encoding.convert`.
This option throws an error if a character cannot be converted, allowing for explicit error handling.

Example:
```javascript
const unicodeArray = Encoding.stringToCode('おにぎり🍙ラーメン🍜');
try {
  const sjisArray = Encoding.convert(unicodeArray, {
    to: 'SJIS',
    from: 'UNICODE',
    fallback: 'error' // Specify 'error' to throw an exception
  });
} catch (e) {
  console.error(e); // Error: Character cannot be represented: [240, 159, 141, 153]
}
```