### PR TITLE
docs(readme): fix wrong character codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Since JavaScript string values are internally encoded as UTF-16 code units
 they cannot directly handle other character encodings as strings. However, encoding.js overcomes this limitation by treating these encodings as arrays instead of strings,
 enabling the conversion between different character sets.
 
-Each character encoding is represented as an array of numbers corresponding to character code values, for example, `[130, 160]` represents "あ" in UTF-8.
+Each character encoding is represented as an array of numbers corresponding to character code values, for example, `[130, 160]` represents "あ" in Shift_JIS.
 
 The array of character codes used in its methods can also be utilized with TypedArray objects, such as `Uint8Array`, or with `Buffer` in Node.js.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -51,7 +51,7 @@ encoding.js は、文字コードの変換や判定をする JavaScript ライ�
 `Shift_JIS` や `EUC-JP`、`ISO-2022-JP` など日本語の文字コードや、 `UTF-8`、`UTF-16` などの Unicode に対応しています。
 
 JavaScript の文字列は内部で UTF-16 コードユニットとして符号化されるため、文字列のままでは他の文字コードを正しく扱えませんが ([参照: ECMAScript® 2019 Language Specification - 6.1.4 The String Type](https://www.ecma-international.org/ecma-262/10.0/index.html#sec-ecmascript-language-types-string-type))、encoding.js では文字列ではなく配列として扱い変換を実現しています。  
-各文字コードは、例えば `[130, 160]` (UTF-8の「あ」) などの文字コード値を持つ数値の配列として扱います。
+各文字コードは、例えば `[130, 160]` (Shift_JIS の「あ」) などの文字コード値を持つ数値の配列として扱います。
 
 また、encoding.js の各メソッドに渡す文字コードの配列は、`Uint8Array` などの TypedArray や Node.js の `Buffer` でも使えます。
 


### PR DESCRIPTION
Resolve #50 
fix wrong character codes in README

> [130, 160] represents "あ" in UTF-8
> https://github.com/polygonplanet/encoding.js/blob/HEAD/README.md
>
> [130, 160] (UTF-8の「あ」)
> https://github.com/polygonplanet/encoding.js/blob/HEAD/README_ja.md

These character encodings are not UTF-8, but are correctly Shift_JIS.
