### PR TITLE
fix: convert wa-row voiced kana (U+30F8/U+30F9) in toHiraganaCase and toKatakanaCase

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -358,6 +358,14 @@ var Encoding = {
       } else if (c === 0x30F7) {
         results[results.length] = 0x308F;
         c = 0x309B;
+      // 「ヰ゛」 => 「ゐ」 + 「゛」
+      } else if (c === 0x30F8) {
+        results[results.length] = 0x3090;
+        c = 0x309B;
+      // 「ヱ゛」 => 「ゑ」 + 「゛」
+      } else if (c === 0x30F9) {
+        results[results.length] = 0x3091;
+        c = 0x309B;
       // 「ヲ゛」 => 「を」 + 「゛」
       } else if (c === 0x30FA) {
         results[results.length] = 0x3092;
@@ -397,9 +405,13 @@ var Encoding = {
       c = data[i++];
       if (c >= 0x3041 && c <= 0x3096) {
         if ((c === 0x308F || // 「わ」 + 「゛」 => 「ワ゛」
+             c === 0x3090 || // 「ゐ」 + 「゛」 => 「ヰ゛」
+             c === 0x3091 || // 「ゑ」 + 「゛」 => 「ヱ゛」
              c === 0x3092) && // 「を」 + 「゛」 => 「ヲ゛」
             i < len && data[i] === 0x309B) {
-          c = c === 0x308F ? 0x30F7 : 0x30FA;
+          c = c === 0x308F ? 0x30F7 :
+              c === 0x3090 ? 0x30F8 :
+              c === 0x3091 ? 0x30F9 : 0x30FA;
           i++;
         } else {
           c += 0x0060;

--- a/tests/test.js
+++ b/tests/test.js
@@ -1517,6 +1517,24 @@ describe('encoding', function() {
       });
     });
 
+    it('toHiraganaCase/toKatakanaCase wa-row voiced kana', function() {
+      // 'ヷヸヹヺ' (U+30F7 - U+30FA) <=> base hiragana + voiced mark (U+309B)
+      var katakana = 'ヷヸヹヺ';
+      var hiragana = 'わ゛ゐ゛ゑ゛を゛';
+
+      assert.equal(encoding.toHiraganaCase(katakana), hiragana);
+      assert.equal(encoding.toKatakanaCase(hiragana), katakana);
+
+      assert.deepEqual(
+        encoding.toHiraganaCase(encoding.stringToCode(katakana)),
+        encoding.stringToCode(hiragana)
+      );
+      assert.deepEqual(
+        encoding.toKatakanaCase(encoding.stringToCode(hiragana)),
+        encoding.stringToCode(katakana)
+      );
+    });
+
     it('toHankanaCase', function() {
       zenkanas.forEach(function(zenkana, i) {
         var expect = hankanas[i];


### PR DESCRIPTION
`toHiraganaCase` and `toKatakanaCase` already handle two of the four wa-row voiced katakana: `ヷ` (U+30F7) is decomposed to `わ゛` and `ヺ` (U+30FA) to `を゛`, and `toKatakanaCase` composes them back. The other two, `ヸ` (U+30F8) and `ヹ` (U+30F9), were left out, so they pass through unconverted:

```js
Encoding.toHiraganaCase('ヷヸヹヺ');      // 'わ゛ヸヹを゛'  (ヸ/ヹ unchanged)
Encoding.toKatakanaCase('わ゛ゐ゛ゑ゛を゛'); // 'ヷヰ゛ヱ゛ヺ'  (ゐ゛/ゑ゛ not composed)
```

The base letters `ヰ`/`ヱ` already convert to `ゐ`/`ゑ` through the usual katakana/hiragana offset, so the voiced forms now follow the same pattern as `ヷ`/`ヺ`:

```js
Encoding.toHiraganaCase('ヷヸヹヺ');      // 'わ゛ゐ゛ゑ゛を゛'
Encoding.toKatakanaCase('わ゛ゐ゛ゑ゛を゛'); // 'ヷヸヹヺ'
```

Added a test covering the round-trip for the full wa-row voiced family. `npm test` passes.
