### PR TITLE
Encode JIS X 0212 characters with the standard 3-byte form

### DIFF
--- a/src/encoding-convert.js
+++ b/src/encoding-convert.js
@@ -706,6 +706,10 @@ function UTF8ToEUCJP(data, options) {
       }
 
       jis = EncodingTable.UTF8_TO_JIS_TABLE[utf8];
+      // JIS X 0212 chars duplicated into JIS X 0208 unassigned rows: use the JIS X 0212 form.
+      if (jis != null && EncodingTable.UTF8_TO_JISX0212_TABLE[utf8] != null) {
+        jis = null;
+      }
       if (jis == null) {
         jis = EncodingTable.UTF8_TO_JISX0212_TABLE[utf8];
         if (jis == null) {
@@ -789,6 +793,10 @@ function UTF8ToJIS(data, options) {
       }
 
       jis = EncodingTable.UTF8_TO_JIS_TABLE[utf8];
+      // JIS X 0212 chars duplicated into JIS X 0208 unassigned rows: use the JIS X 0212 form.
+      if (jis != null && EncodingTable.UTF8_TO_JISX0212_TABLE[utf8] != null) {
+        jis = null;
+      }
       if (jis == null) {
         jis = EncodingTable.UTF8_TO_JISX0212_TABLE[utf8];
         if (jis == null) {

--- a/tests/test.js
+++ b/tests/test.js
@@ -953,6 +953,44 @@ describe('encoding', function() {
       assert.deepEqual(encoded_sjis_to_utf8, jisx0212_sjis_array);
     });
 
+    it('encodes JIS X 0212 with the 3-byte SS3 form, not JIS X 0208 unassigned rows', function() {
+      var jisTable = require('../src/utf8-to-jis-table');
+      var jisx0212Table = require('../src/utf8-to-jisx0212-table');
+      var keyToCode = function(key) {
+        var bytes = [];
+        var n = parseInt(key, 10);
+        while (n > 0) { bytes.unshift(n & 0xFF); n = n >>> 8; }
+        return Buffer.from(bytes).toString('utf8').codePointAt(0);
+      };
+      // Characters present in both tables are JIS X 0212 code points that are
+      // also duplicated into the JIS X 0208 table at rows unassigned by
+      // JIS X 0208 (NEC/IBM extension rows).
+      var shadowed = Object.keys(jisTable)
+        .filter(function(key) { return jisx0212Table[key] != null; })
+        .map(keyToCode);
+      assert.equal(shadowed.length, 280);
+
+      shadowed.forEach(function(code) {
+        var eucjp = encoding.convert([code], 'EUCJP', 'UNICODE');
+        // EUC-JP code set 3: 0x8F <b1> <b2>, trailing bytes in 0xA1-0xFE.
+        assert.equal(eucjp[0], 0x8F);
+        assert(eucjp[1] >= 0xA1 && eucjp[1] <= 0xFE);
+        assert(eucjp[2] >= 0xA1 && eucjp[2] <= 0xFE);
+        assert.deepEqual(encoding.convert(eucjp, 'UNICODE', 'EUCJP'), [code]);
+
+        var jis = encoding.convert([code], 'JIS', 'UNICODE');
+        // ISO-2022-JP designates JIS X 0212 with ESC $ ( D.
+        assert.deepEqual(jis.slice(0, 4), [0x1B, 0x24, 0x28, 0x44]);
+        assert.deepEqual(encoding.convert(jis, 'UNICODE', 'JIS'), [code]);
+      });
+
+      // Exact bytes: U+4E28 (JIS X 0212 kuten 16-09) and U+2116 (duplicated at row 13).
+      assert.deepEqual(encoding.convert([0x4E28], 'EUCJP', 'UNICODE'), [0x8F, 0xB0, 0xA9]);
+      assert.deepEqual(encoding.convert([0x2116], 'EUCJP', 'UNICODE'), [0x8F, 0xA2, 0xF1]);
+      // A genuine JIS X 0208 kanji (U+4E9C) keeps its 2-byte form.
+      assert.deepEqual(encoding.convert([0x4E9C], 'EUCJP', 'UNICODE'), [0xB0, 0xA1]);
+    });
+
     var encodingNames = [
       'UTF16', 'UTF16BE', 'UTF16LE', 'UNICODE', 'JIS', 'EUCJP', 'UTF8'
     ];


### PR DESCRIPTION
The EUC-JP and ISO-2022-JP encoders emit 280 JIS X 0212 characters in a non-standard 2-byte form that no standard decoder accepts. These code points are duplicated into `UTF8_TO_JIS_TABLE` at rows unassigned by JIS X 0208, and that table is checked before `UTF8_TO_JISX0212_TABLE`, so the existing 3-byte path (`encoding-convert.js:718`) is never reached.

For example U+4E28 encodes to `[0xF9,0xAD]`, which Python's `euc_jp` rejects, whereas the library's own decoder and the changelog's "Supports JIS X 0212:1990" expect `[0x8F,0xB0,0xA9]`:

```js
Encoding.convert([0x4E28], 'EUCJP', 'UNICODE') // [249,173], not [143,176,169]
```

When a code point is present in both tables it now uses the JIS X 0212 form. The 280 affected characters occupy JIS X 0208 rows 13 and 89-92, which are all unassigned, so no genuine JIS X 0208 character is rerouted and Shift_JIS output is unchanged. Verified against Python `euc_jp`/`iso2022_jp_2`: all 280 now round-trip; `npm test` passes (178).
